### PR TITLE
Fixed Issue 6

### DIFF
--- a/js/genetics.js
+++ b/js/genetics.js
@@ -631,7 +631,7 @@ var Genetics = Genetics || {};
 
       var fittest = population.getFittest();
       var totalTime = ((new Date().getTime() - startTime) / 1000);
-      var timePerGeneration = (totalTime / jiffies) * 100;
+      var timePerGeneration = (totalTime / jiffies) * 1000;
       var timePerImprovment = 0;
       var currentFitness = (fittest.fitness * 100);
 


### PR DESCRIPTION

Fixes #6
I fixed issue #6 by changing the multiplier for timePerGeneration from 100 to 1000.
This makes the displayed amount of milliseconds per generation from one order of magnitude too low to the correct amount.
-Benji







thanks chris