### PR TITLE
Implemented average time per improvement feature

### DIFF
--- a/js/genetics.js
+++ b/js/genetics.js
@@ -61,6 +61,7 @@ var Genetics = Genetics || {};
    */
   var clock;
   var jiffies;
+  var numberOfImprovements
   var geneSize;
   var dnaLength;
   var lowestFitness;
@@ -618,6 +619,7 @@ var Genetics = Genetics || {};
 
     if (isStopped()) {
       jiffies = 0;
+      numberOfImprovements = 0;
       startTime = new Date().getTime();
       population = new Population(populationSize);
     }
@@ -632,13 +634,22 @@ var Genetics = Genetics || {};
       var fittest = population.getFittest();
       var totalTime = ((new Date().getTime() - startTime) / 1000);
       var timePerGeneration = (totalTime / jiffies) * 1000;
-      var timePerImprovment = 0;
+      var timePerImprovment = (totalTime / numberOfImprovements) * 1000;
       var currentFitness = (fittest.fitness * 100);
+      
+      if (currentFitness < lowestFitness) {
+	  lowestFitness = currentFitness;
+      } else {
+	  lowestFitness = lowestFitness;
+      }
 
-      lowestFitness = (currentFitness < lowestFitness) ?
-          currentFitness : lowestFitness;
-      highestFitness = (currentFitness > highestFitness) ?
-          currentFitness : highestFitness;
+      if (currentFitness > highestFitness) {
+	  highestFitness = currentFitness;
+	  /* Improvement was made */
+	  numberOfImprovements++;
+      } else {
+	  highestFitness = highestFitness;
+      }
 
       /* Draw the best fit to output */
       fittest.draw(outputCtx, 350, 350);


### PR DESCRIPTION
Was previously always 0, now calculates the average in a similar fashion to average time per
generation. Rewrote the ternary statements that checked for
highest/lowest fitness on each generation to accomodate incrementing the
new variable, numberOfImprovements. Results can be seen in screenshot below.

![avg_time_per_imp_fix](https://cloud.githubusercontent.com/assets/8472688/11084730/d21f4818-880c-11e5-91b3-714f9f89142d.png)
